### PR TITLE
feat: write dotted keys into existing nested files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,8 +50,6 @@
         "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true
-        },
-        "policy": {
         }
     },
     "extra": {

--- a/src/TranslationDumper.php
+++ b/src/TranslationDumper.php
@@ -4,6 +4,7 @@ namespace Bambamboole\LaravelTranslationDumper;
 
 use Bambamboole\LaravelTranslationDumper\DTO\Translation;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
 
 class TranslationDumper implements TranslationDumperInterface
 {
@@ -49,7 +50,7 @@ class TranslationDumper implements TranslationDumperInterface
         foreach ($byFile as $group => $entries) {
             $values = [];
             foreach ($entries as [$remainingKey, $value]) {
-                $this->assignNestedValue($values, explode('.', $remainingKey), $value);
+                Arr::set($values, $remainingKey, $value);
             }
 
             $file = "{$this->languageFilePath}/{$this->locale}/{$group}.php";
@@ -74,11 +75,15 @@ class TranslationDumper implements TranslationDumperInterface
         $segments = explode('.', $dottedKey);
         $base = "{$this->languageFilePath}/{$this->locale}";
 
+        // Walk from the deepest possible nested file down to the top level and
+        // use the first one that already exists, so the most specific existing
+        // file wins and we stop probing as soon as we find it.
         $depth = 1;
-        for ($candidateDepth = 2; $candidateDepth < count($segments); $candidateDepth++) {
+        for ($candidateDepth = count($segments) - 1; $candidateDepth >= 2; $candidateDepth--) {
             $candidate = $base.'/'.implode('/', array_slice($segments, 0, $candidateDepth)).'.php';
             if ($this->filesystem->exists($candidate)) {
                 $depth = $candidateDepth;
+                break;
             }
         }
 
@@ -86,24 +91,6 @@ class TranslationDumper implements TranslationDumperInterface
             implode('/', array_slice($segments, 0, $depth)),
             implode('.', array_slice($segments, $depth)),
         ];
-    }
-
-    /**
-     * @param  array<string, mixed>  $target
-     * @param  string[]  $keys
-     */
-    private function assignNestedValue(array &$target, array $keys, string $value): void
-    {
-        $current = &$target;
-        while (count($keys) > 1) {
-            $key = array_shift($keys);
-            if (! isset($current[$key]) || ! is_array($current[$key])) {
-                $current[$key] = [];
-            }
-            $current = &$current[$key];
-        }
-        $current[array_shift($keys)] = $value;
-        unset($current);
     }
 
     /** @param Translation[] $translations */

--- a/src/TranslationDumper.php
+++ b/src/TranslationDumper.php
@@ -37,15 +37,73 @@ class TranslationDumper implements TranslationDumperInterface
     /** @param Translation[] $translations */
     private function dumpPhpTranslations(array $translations): void
     {
-        $result = $this->transformDottedStringsToArray($translations);
-        foreach ($result as $key => $value) {
-            $path = $this->languageFilePath.'/'.$this->locale;
-            $file = "{$path}/{$key}.php";
-            $keys = $this->mergeWithExistingKeys($file, $value);
+        // Group every translation by the file it belongs in. A dotted key goes
+        // into a flat top level file by default, but if a matching nested file
+        // already exists we write into that one instead.
+        $byFile = [];
+        foreach ($translations as $translation) {
+            [$group, $remainingKey] = $this->resolveTargetFile($translation->key);
+            $byFile[$group][] = [$remainingKey, $this->prepareTranslationValue($translation)];
+        }
 
-            $this->filesystem->ensureDirectoryExists($path);
+        foreach ($byFile as $group => $entries) {
+            $values = [];
+            foreach ($entries as [$remainingKey, $value]) {
+                $this->assignNestedValue($values, explode('.', $remainingKey), $value);
+            }
+
+            $file = "{$this->languageFilePath}/{$this->locale}/{$group}.php";
+            $keys = $this->mergeWithExistingKeys($file, $values);
+
+            $this->filesystem->ensureDirectoryExists(dirname($file));
             $this->filesystem->put($file, ArrayExporter::export($keys));
         }
+    }
+
+    /**
+     * Decide which file a dotted key should be written to. By default the first
+     * segment becomes a flat top level file (e.g. entities.salesOrder.title ->
+     * entities.php). If a deeper nested file already exists on disk we target
+     * that one instead (entities/salesOrder.php), so existing nested files keep
+     * receiving their keys while new nested files are never created.
+     *
+     * @return array{0: string, 1: string} the group path and the remaining dotted key
+     */
+    private function resolveTargetFile(string $dottedKey): array
+    {
+        $segments = explode('.', $dottedKey);
+        $base = "{$this->languageFilePath}/{$this->locale}";
+
+        $depth = 1;
+        for ($candidateDepth = 2; $candidateDepth < count($segments); $candidateDepth++) {
+            $candidate = $base.'/'.implode('/', array_slice($segments, 0, $candidateDepth)).'.php';
+            if ($this->filesystem->exists($candidate)) {
+                $depth = $candidateDepth;
+            }
+        }
+
+        return [
+            implode('/', array_slice($segments, 0, $depth)),
+            implode('.', array_slice($segments, $depth)),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $target
+     * @param  string[]  $keys
+     */
+    private function assignNestedValue(array &$target, array $keys, string $value): void
+    {
+        $current = &$target;
+        while (count($keys) > 1) {
+            $key = array_shift($keys);
+            if (! isset($current[$key]) || ! is_array($current[$key])) {
+                $current[$key] = [];
+            }
+            $current = &$current[$key];
+        }
+        $current[array_shift($keys)] = $value;
+        unset($current);
     }
 
     /** @param Translation[] $translations */
@@ -68,30 +126,6 @@ class TranslationDumper implements TranslationDumperInterface
         ksort($mergedTranslations, SORT_NATURAL | SORT_FLAG_CASE);
         $this->filesystem->ensureDirectoryExists($this->languageFilePath);
         $this->filesystem->put($file, json_encode($mergedTranslations, JSON_PRETTY_PRINT).PHP_EOL);
-    }
-
-    /** @param Translation[] $translations */
-    private function transformDottedStringsToArray(array $translations): array
-    {
-        $result = [];
-
-        foreach ($translations as $translation) {
-            $keys = explode('.', $translation->key);
-            $current = &$result;
-
-            while (count($keys) > 1) {
-                $key = array_shift($keys);
-                if (! isset($current[$key])) {
-                    $current[$key] = [];
-                }
-                $current = &$current[$key];
-            }
-
-            $lastKey = array_shift($keys);
-            $current[$lastKey] = $this->prepareTranslationValue($translation);
-        }
-
-        return $result;
     }
 
     private function mergeWithExistingKeys(string $filePath, array $newKeys): array

--- a/tests/Feature/NestedFileDumpTest.php
+++ b/tests/Feature/NestedFileDumpTest.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+use Bambamboole\LaravelTranslationDumper\DTO\Translation;
+use Bambamboole\LaravelTranslationDumper\TranslationDumper;
+use Illuminate\Filesystem\Filesystem;
+
+beforeEach(function () {
+    $this->fs = new Filesystem;
+    $this->lang = sys_get_temp_dir().'/ltd-nested-'.uniqid('', true);
+    $this->fs->ensureDirectoryExists($this->lang.'/en/entities');
+});
+
+afterEach(function () {
+    $this->fs->deleteDirectory($this->lang);
+});
+
+it('writes a dotted key into an existing nested file instead of a flat one', function () {
+    $this->fs->put(
+        $this->lang.'/en/entities/salesOrder.php',
+        "<?php declare(strict_types=1);\n\nreturn ['title' => 'Sales order'];\n",
+    );
+
+    (new TranslationDumper($this->fs, $this->lang, 'en'))->dump([
+        new Translation('entities.salesOrder.status', 'x-entities.salesOrder.status'),
+    ]);
+
+    // It merged into the existing nested file ...
+    expect(require $this->lang.'/en/entities/salesOrder.php')->toEqual([
+        'status' => 'x-entities.salesOrder.status',
+        'title' => 'Sales order',
+    ]);
+    // ... and did not create a flat entities.php alongside it.
+    expect($this->fs->exists($this->lang.'/en/entities.php'))->toBeFalse();
+});
+
+it('still writes to a flat top level file when no nested file exists', function () {
+    (new TranslationDumper($this->fs, $this->lang, 'en'))->dump([
+        new Translation('foo.bar.baz', 'x-foo.bar.baz'),
+    ]);
+
+    expect(require $this->lang.'/en/foo.php')->toEqual([
+        'bar' => ['baz' => 'x-foo.bar.baz'],
+    ]);
+    // No nested foo/ directory or file was created.
+    expect($this->fs->exists($this->lang.'/en/foo'))->toBeFalse();
+});
+
+it('prefers the deepest existing nested file', function () {
+    $this->fs->ensureDirectoryExists($this->lang.'/en/entities/salesOrder');
+    $this->fs->put(
+        $this->lang.'/en/entities/salesOrder/lines.php',
+        "<?php declare(strict_types=1);\n\nreturn ['label' => 'Lines'];\n",
+    );
+
+    (new TranslationDumper($this->fs, $this->lang, 'en'))->dump([
+        new Translation('entities.salesOrder.lines.total', 'x-entities.salesOrder.lines.total'),
+    ]);
+
+    expect(require $this->lang.'/en/entities/salesOrder/lines.php')->toEqual([
+        'label' => 'Lines',
+        'total' => 'x-entities.salesOrder.lines.total',
+    ]);
+    expect($this->fs->exists($this->lang.'/en/entities.php'))->toBeFalse();
+    expect($this->fs->exists($this->lang.'/en/entities/salesOrder.php'))->toBeFalse();
+});

--- a/tests/Unit/TranslationDumperTest.php
+++ b/tests/Unit/TranslationDumperTest.php
@@ -26,26 +26,21 @@ class TranslationDumperTest extends TestCase
     #[DataProvider('provideTestData')]
     public function test_it_dumps_dotted_keys_as_expected(array $given, array $expected): void
     {
+        // No translation files exist yet, so every key falls back to a flat
+        // top level file named after its first segment.
+        $this->filesystem->method('exists')->willReturn(false);
+
         if (empty($expected)) {
-            $this->filesystem
-                ->expects($this->never())
-                ->method('exists');
             $this->filesystem
                 ->expects($this->never())
                 ->method('put');
         } else {
-            foreach ($expected as $key => $expectedArray) {
-                $file = self::TEST_LANGUAGE_FILE_PATH.'/'.self::TEST_LOCALE.'/'.$key.'.php';
-                $this->filesystem
-                    ->expects($this->once())
-                    ->method('exists')
-                    ->with($file)
-                    ->willReturn(false);
-                $this->filesystem
-                    ->expects($this->once())
-                    ->method('put')
-                    ->with($file, ArrayExporter::export($expectedArray));
-            }
+            $key = array_key_first($expected);
+            $file = self::TEST_LANGUAGE_FILE_PATH.'/'.self::TEST_LOCALE.'/'.$key.'.php';
+            $this->filesystem
+                ->expects($this->once())
+                ->method('put')
+                ->with($file, ArrayExporter::export($expected[$key]));
         }
 
         $this->createTranslationDumper()->dump($given);


### PR DESCRIPTION
## Summary

When dumping a missing dotted translation key, the dumper now prefers an **already-existing** nested file that matches a prefix of the key, instead of always writing to a flat top-level file.

Example: with `lang/en/entities/salesOrder.php` present, dumping `entities.salesOrder.status` writes `status` into that file rather than creating `lang/en/entities.php`.

Rules:
- **Never creates new nested files/directories** — a key only lands in a nested file if that file already exists.
- Falls back to the existing behavior (flat top-level file named after the first segment) when no matching nested file exists.
- Prefers the **deepest** existing nested file when several prefixes match.

This pairs with `bambamboole/laravel-i18next`, which reads nested translation files namespaced by their path (`entities.salesOrder.*`); now keys saved via its store route round-trip back into the right nested file.

## Tests

- New `tests/Feature/NestedFileDumpTest.php` covers: writing into an existing nested file (and *not* creating a flat one), the flat-file fallback, and preferring the deepest existing nested file.
- Existing unit/feature coverage updated for the new file-resolution path.

Full suite (18 tests) + PHPStan + Pint green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)