### PR TITLE
feat!: TranslationWriter interface + FileTranslationWriter (with nested-file creation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,39 @@ they will be written to the respective translation files in the structure that t
 part of the key is the file name and the rest is the nested path of a PHP array.
 As value it takes the translation key itself prefixed by a configurable prefix.
 
+By default a dotted key goes into a flat top level file (`a.b.c` → `a.php`), unless a
+matching nested file already exists (`a/b.php`), in which case the key is written there.
+
+## Writing translations
+
+Persistence is handled behind the `TranslationWriter` interface, and the package ships
+a `FileTranslationWriter` that reads, merges and writes the lang files (PHP via
+`brick/varexporter`, JSON with unescaped unicode/slashes, both with an exclusive lock).
+Bind your own implementation to `TranslationWriter::class` to persist elsewhere.
+
+```php
+use Bambamboole\LaravelTranslationDumper\FileTranslationWriter;
+use Bambamboole\LaravelTranslationDumper\TranslationDumper;
+
+$dumper = new TranslationDumper(new FileTranslationWriter($filesystem, lang_path()), 'en');
+```
+
+### Dumping into a specific (nested) file
+
+Pass a `group` to write every translation into one file, **creating it if needed** —
+the group is the path under the locale directory, so it can be nested:
+
+```php
+$dumper->dump([
+    new Translation('subtitle', 'x-subtitle'),
+    new Translation('status.open', 'x-status.open'),
+], 'entities/salesOrder');
+// -> lang/en/entities/salesOrder.php  (created), keys relative to the group
+```
+
+This pairs with i18next namespaces (`entities/salesOrder`), where the namespace is the
+group path: missing keys round-trip straight back into the matching nested file.
+
 ### Testing
 
 ```bash

--- a/src/DumpingTranslator.php
+++ b/src/DumpingTranslator.php
@@ -61,8 +61,7 @@ class DumpingTranslator implements TranslatorContract
         try {
             $this->translationDumper->dump($this->missingTranslations);
         } catch (\Throwable $e) {
-            // Never let a dump failure escape the destructor (it would surface as
-            // a fatal error during shutdown). Report it if a handler is available.
+            // a throwing destructor becomes a fatal error during shutdown
             if (function_exists('report')) {
                 report($e);
             }

--- a/src/DumpingTranslator.php
+++ b/src/DumpingTranslator.php
@@ -58,7 +58,15 @@ class DumpingTranslator implements TranslatorContract
             return;
         }
 
-        $this->translationDumper->dump($this->missingTranslations);
+        try {
+            $this->translationDumper->dump($this->missingTranslations);
+        } catch (\Throwable $e) {
+            // Never let a dump failure escape the destructor (it would surface as
+            // a fatal error during shutdown). Report it if a handler is available.
+            if (function_exists('report')) {
+                report($e);
+            }
+        }
     }
 
     private function shouldBeIgnored(string $key): bool

--- a/src/FileTranslationWriter.php
+++ b/src/FileTranslationWriter.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+
+namespace Bambamboole\LaravelTranslationDumper;
+
+use Illuminate\Filesystem\Filesystem;
+
+class FileTranslationWriter implements TranslationWriter
+{
+    public function __construct(
+        private readonly Filesystem $filesystem,
+        private readonly string $languageFilePath,
+    ) {}
+
+    public function hasGroup(string $locale, string $group): bool
+    {
+        return $this->filesystem->exists($this->groupPath($locale, $group));
+    }
+
+    public function writeGroup(string $locale, string $group, array $translations): void
+    {
+        if ($translations === []) {
+            return;
+        }
+
+        $file = $this->groupPath($locale, $group);
+        $existing = $this->filesystem->exists($file) ? require $file : [];
+        $merged = $this->mergeArrays($existing, $translations);
+
+        $this->filesystem->ensureDirectoryExists(dirname($file));
+        $this->filesystem->put($file, ArrayExporter::export($merged), lock: true);
+    }
+
+    public function writeJson(string $locale, array $translations): void
+    {
+        if ($translations === []) {
+            return;
+        }
+
+        $file = "{$this->languageFilePath}/{$locale}.json";
+        $existing = $this->filesystem->exists($file)
+            ? (array) json_decode($this->filesystem->get($file), true)
+            : [];
+
+        $merged = array_merge($existing, $translations);
+        ksort($merged, SORT_NATURAL | SORT_FLAG_CASE);
+
+        $this->filesystem->ensureDirectoryExists($this->languageFilePath);
+        $this->filesystem->put(
+            $file,
+            json_encode($merged, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).PHP_EOL,
+            lock: true,
+        );
+    }
+
+    private function groupPath(string $locale, string $group): string
+    {
+        return "{$this->languageFilePath}/{$locale}/{$group}.php";
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $array1
+     * @param  array<array-key, mixed>  $array2
+     * @return array<array-key, mixed>
+     */
+    private function mergeArrays(array $array1, array $array2): array
+    {
+        $merged = $array1;
+
+        foreach ($array2 as $key => $value) {
+            if (is_array($value) && isset($merged[$key]) && is_array($merged[$key])) {
+                $merged[$key] = $this->mergeArrays($merged[$key], $value);
+            } elseif (is_numeric($key)) {
+                if (! in_array($value, $merged)) {
+                    $merged[] = $value;
+                }
+            } else {
+                $merged[$key] = $value;
+            }
+        }
+        ksort($merged);
+
+        return $merged;
+    }
+}

--- a/src/LaravelTranslationDumperServiceProvider.php
+++ b/src/LaravelTranslationDumperServiceProvider.php
@@ -25,10 +25,14 @@ class LaravelTranslationDumperServiceProvider extends ServiceProvider
 
         if ($this->app->make(Repository::class)->get('translation.dump_translations')) {
             $this->app->singleton(
+                TranslationWriter::class,
+                static fn (Application $app) => new FileTranslationWriter(new Filesystem, $app->langPath()),
+            );
+
+            $this->app->singleton(
                 TranslationDumper::class,
                 static fn (Application $app) => new TranslationDumper(
-                    new Filesystem,
-                    $app->langPath(),
+                    $app->make(TranslationWriter::class),
                     $app->make(Repository::class)->get('app.locale'),
                 ),
             );

--- a/src/TranslationDumper.php
+++ b/src/TranslationDumper.php
@@ -17,12 +17,7 @@ class TranslationDumper implements TranslationDumperInterface
         $this->locale = $locale;
     }
 
-    /**
-     * @param  Translation[]  $translations
-     * @param  ?string  $group  When given, every translation is written into this
-     *                          group file (created if needed), with keys relative
-     *                          to the group (e.g. "entities/salesOrder").
-     */
+    /** @param  Translation[]  $translations */
     public function dump(array $translations, ?string $group = null): void
     {
         if ($group !== null) {
@@ -45,11 +40,7 @@ class TranslationDumper implements TranslationDumperInterface
         $this->dumpJsonTranslations($jsonTranslations);
     }
 
-    /**
-     * Write every translation into one explicit group file, keys relative to it.
-     *
-     * @param  Translation[]  $translations
-     */
+    /** @param  Translation[]  $translations */
     private function dumpIntoGroup(array $translations, string $group): void
     {
         $values = [];
@@ -63,9 +54,6 @@ class TranslationDumper implements TranslationDumperInterface
     /** @param  Translation[]  $translations */
     private function dumpPhpTranslations(array $translations): void
     {
-        // Group every translation by the file it belongs in. A dotted key goes
-        // into a flat top level file by default, but if a matching nested file
-        // already exists we write into that one instead.
         $byFile = [];
         foreach ($translations as $translation) {
             [$group, $remainingKey] = $this->resolveTargetFile($translation->key);
@@ -82,15 +70,7 @@ class TranslationDumper implements TranslationDumperInterface
         }
     }
 
-    /**
-     * Decide which group a dotted key should be written to. By default the first
-     * segment becomes a flat top level file (entities.salesOrder.title ->
-     * entities). If a deeper nested file already exists we target that one
-     * instead (entities/salesOrder), so existing nested files keep receiving
-     * their keys while new nested files are never created implicitly.
-     *
-     * @return array{0: string, 1: string} the group path and the remaining dotted key
-     */
+    /** @return array{0: string, 1: string} */
     private function resolveTargetFile(string $dottedKey): array
     {
         $segments = explode('.', $dottedKey);

--- a/src/TranslationDumper.php
+++ b/src/TranslationDumper.php
@@ -57,7 +57,7 @@ class TranslationDumper implements TranslationDumperInterface
             $keys = $this->mergeWithExistingKeys($file, $values);
 
             $this->filesystem->ensureDirectoryExists(dirname($file));
-            $this->filesystem->put($file, ArrayExporter::export($keys));
+            $this->filesystem->put($file, ArrayExporter::export($keys), lock: true);
         }
     }
 
@@ -112,7 +112,11 @@ class TranslationDumper implements TranslationDumperInterface
         $mergedTranslations = array_merge($existingKeys, $newTranslations);
         ksort($mergedTranslations, SORT_NATURAL | SORT_FLAG_CASE);
         $this->filesystem->ensureDirectoryExists($this->languageFilePath);
-        $this->filesystem->put($file, json_encode($mergedTranslations, JSON_PRETTY_PRINT).PHP_EOL);
+        $this->filesystem->put(
+            $file,
+            json_encode($mergedTranslations, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).PHP_EOL,
+            lock: true,
+        );
     }
 
     private function mergeWithExistingKeys(string $filePath, array $newKeys): array

--- a/src/TranslationDumper.php
+++ b/src/TranslationDumper.php
@@ -3,14 +3,12 @@
 namespace Bambamboole\LaravelTranslationDumper;
 
 use Bambamboole\LaravelTranslationDumper\DTO\Translation;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 
 class TranslationDumper implements TranslationDumperInterface
 {
     public function __construct(
-        private readonly Filesystem $filesystem,
-        private readonly string $languageFilePath,
+        private readonly TranslationWriter $writer,
         private string $locale,
     ) {}
 
@@ -19,9 +17,20 @@ class TranslationDumper implements TranslationDumperInterface
         $this->locale = $locale;
     }
 
-    /** @param Translation[] $translations */
-    public function dump(array $translations): void
+    /**
+     * @param  Translation[]  $translations
+     * @param  ?string  $group  When given, every translation is written into this
+     *                          group file (created if needed), with keys relative
+     *                          to the group (e.g. "entities/salesOrder").
+     */
+    public function dump(array $translations, ?string $group = null): void
     {
+        if ($group !== null) {
+            $this->dumpIntoGroup($translations, $group);
+
+            return;
+        }
+
         $jsonTranslations = [];
         $phpTranslations = [];
         foreach ($translations as $translation) {
@@ -31,11 +40,27 @@ class TranslationDumper implements TranslationDumperInterface
                 $jsonTranslations[] = $translation;
             }
         }
+
         $this->dumpPhpTranslations($phpTranslations);
         $this->dumpJsonTranslations($jsonTranslations);
     }
 
-    /** @param Translation[] $translations */
+    /**
+     * Write every translation into one explicit group file, keys relative to it.
+     *
+     * @param  Translation[]  $translations
+     */
+    private function dumpIntoGroup(array $translations, string $group): void
+    {
+        $values = [];
+        foreach ($translations as $translation) {
+            Arr::set($values, $translation->key, $this->prepareTranslationValue($translation));
+        }
+
+        $this->writer->writeGroup($this->locale, $group, $values);
+    }
+
+    /** @param  Translation[]  $translations */
     private function dumpPhpTranslations(array $translations): void
     {
         // Group every translation by the file it belongs in. A dotted key goes
@@ -53,35 +78,27 @@ class TranslationDumper implements TranslationDumperInterface
                 Arr::set($values, $remainingKey, $value);
             }
 
-            $file = "{$this->languageFilePath}/{$this->locale}/{$group}.php";
-            $keys = $this->mergeWithExistingKeys($file, $values);
-
-            $this->filesystem->ensureDirectoryExists(dirname($file));
-            $this->filesystem->put($file, ArrayExporter::export($keys), lock: true);
+            $this->writer->writeGroup($this->locale, (string) $group, $values);
         }
     }
 
     /**
-     * Decide which file a dotted key should be written to. By default the first
-     * segment becomes a flat top level file (e.g. entities.salesOrder.title ->
-     * entities.php). If a deeper nested file already exists on disk we target
-     * that one instead (entities/salesOrder.php), so existing nested files keep
-     * receiving their keys while new nested files are never created.
+     * Decide which group a dotted key should be written to. By default the first
+     * segment becomes a flat top level file (entities.salesOrder.title ->
+     * entities). If a deeper nested file already exists we target that one
+     * instead (entities/salesOrder), so existing nested files keep receiving
+     * their keys while new nested files are never created implicitly.
      *
      * @return array{0: string, 1: string} the group path and the remaining dotted key
      */
     private function resolveTargetFile(string $dottedKey): array
     {
         $segments = explode('.', $dottedKey);
-        $base = "{$this->languageFilePath}/{$this->locale}";
 
-        // Walk from the deepest possible nested file down to the top level and
-        // use the first one that already exists, so the most specific existing
-        // file wins and we stop probing as soon as we find it.
         $depth = 1;
         for ($candidateDepth = count($segments) - 1; $candidateDepth >= 2; $candidateDepth--) {
-            $candidate = $base.'/'.implode('/', array_slice($segments, 0, $candidateDepth)).'.php';
-            if ($this->filesystem->exists($candidate)) {
+            $candidate = implode('/', array_slice($segments, 0, $candidateDepth));
+            if ($this->writer->hasGroup($this->locale, $candidate)) {
                 $depth = $candidateDepth;
                 break;
             }
@@ -93,61 +110,15 @@ class TranslationDumper implements TranslationDumperInterface
         ];
     }
 
-    /** @param Translation[] $translations */
+    /** @param  Translation[]  $translations */
     private function dumpJsonTranslations(array $translations): void
     {
-        if (empty($translations)) {
-            return;
-        }
-        $newTranslations = collect($translations)
-            ->mapWithKeys(function (Translation $translation) {
-                return [$translation->key => $this->prepareTranslationValue($translation)];
-            })
-            ->toArray();
-        $file = "{$this->languageFilePath}/{$this->locale}.json";
-        $existingKeys = $this->filesystem->exists($file)
-            ? json_decode($this->filesystem->get($file), true)
-            : [];
-
-        $mergedTranslations = array_merge($existingKeys, $newTranslations);
-        ksort($mergedTranslations, SORT_NATURAL | SORT_FLAG_CASE);
-        $this->filesystem->ensureDirectoryExists($this->languageFilePath);
-        $this->filesystem->put(
-            $file,
-            json_encode($mergedTranslations, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).PHP_EOL,
-            lock: true,
-        );
-    }
-
-    private function mergeWithExistingKeys(string $filePath, array $newKeys): array
-    {
-        if ($this->filesystem->exists($filePath)) {
-            $existingKeys = require $filePath;
-        } else {
-            $existingKeys = [];
+        $values = [];
+        foreach ($translations as $translation) {
+            $values[$translation->key] = $this->prepareTranslationValue($translation);
         }
 
-        return $this->mergeArrays($existingKeys, $newKeys);
-    }
-
-    private function mergeArrays(array $array1, array $array2): array
-    {
-        $merged = $array1;
-
-        foreach ($array2 as $key => $value) {
-            if (is_array($value) && isset($merged[$key]) && is_array($merged[$key])) {
-                $merged[$key] = $this->mergeArrays($merged[$key], $value);
-            } elseif (is_numeric($key)) {
-                if (! in_array($value, $merged)) {
-                    $merged[] = $value;
-                }
-            } else {
-                $merged[$key] = $value;
-            }
-        }
-        ksort($merged);
-
-        return $merged;
+        $this->writer->writeJson($this->locale, $values);
     }
 
     private function prepareTranslationValue(Translation $translation): string

--- a/src/TranslationDumperInterface.php
+++ b/src/TranslationDumperInterface.php
@@ -2,9 +2,14 @@
 
 namespace Bambamboole\LaravelTranslationDumper;
 
+use Bambamboole\LaravelTranslationDumper\DTO\Translation;
+
 interface TranslationDumperInterface
 {
     public function setLocale(string $locale): void;
 
-    public function dump(array $translations): void;
+    /**
+     * @param  array<int, Translation>  $translations
+     */
+    public function dump(array $translations, ?string $group = null): void;
 }

--- a/src/TranslationWriter.php
+++ b/src/TranslationWriter.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Bambamboole\LaravelTranslationDumper;
+
+interface TranslationWriter
+{
+    /**
+     * Whether a PHP group already exists for the locale. "group" is the path of
+     * the file under the locale directory without the extension, e.g. "auth" or
+     * "entities/salesOrder".
+     */
+    public function hasGroup(string $locale, string $group): bool;
+
+    /**
+     * Merge the given (nested) translations into the locale's PHP group file,
+     * creating it if it does not exist yet, and persist it.
+     *
+     * @param  array<string, mixed>  $translations
+     */
+    public function writeGroup(string $locale, string $group, array $translations): void;
+
+    /**
+     * Merge the given translations into the locale's JSON file and persist it.
+     *
+     * @param  array<string, string>  $translations
+     */
+    public function writeJson(string $locale, array $translations): void;
+}

--- a/src/TranslationWriter.php
+++ b/src/TranslationWriter.php
@@ -4,25 +4,11 @@ namespace Bambamboole\LaravelTranslationDumper;
 
 interface TranslationWriter
 {
-    /**
-     * Whether a PHP group already exists for the locale. "group" is the path of
-     * the file under the locale directory without the extension, e.g. "auth" or
-     * "entities/salesOrder".
-     */
     public function hasGroup(string $locale, string $group): bool;
 
-    /**
-     * Merge the given (nested) translations into the locale's PHP group file,
-     * creating it if it does not exist yet, and persist it.
-     *
-     * @param  array<string, mixed>  $translations
-     */
+    /** @param  array<string, mixed>  $translations */
     public function writeGroup(string $locale, string $group, array $translations): void;
 
-    /**
-     * Merge the given translations into the locale's JSON file and persist it.
-     *
-     * @param  array<string, string>  $translations
-     */
+    /** @param  array<string, string>  $translations */
     public function writeJson(string $locale, array $translations): void;
 }

--- a/tests/Feature/Integration/ServiceProviderTest.php
+++ b/tests/Feature/Integration/ServiceProviderTest.php
@@ -19,8 +19,6 @@ it('binds the configured translation dumper', function () {
 });
 
 it('still resolves translations through the decorated translator', function () {
-    // A missing key is returned verbatim by Laravel; the decorator records it
-    // for dumping without changing the returned value.
     expect(trans('some.missing.key'))->toBe('some.missing.key')
         ->and(app('translator')->getLocale())->toBe(config('app.locale'));
 });

--- a/tests/Feature/JsonEncodingTest.php
+++ b/tests/Feature/JsonEncodingTest.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Bambamboole\LaravelTranslationDumper\DTO\Translation;
+use Bambamboole\LaravelTranslationDumper\FileTranslationWriter;
 use Bambamboole\LaravelTranslationDumper\TranslationDumper;
 use Illuminate\Filesystem\Filesystem;
 
@@ -15,7 +16,7 @@ afterEach(function () {
 });
 
 it('writes JSON translations with unescaped unicode and slashes', function () {
-    (new TranslationDumper($this->fs, $this->lang, 'de'))->dump([
+    (new TranslationDumper(new FileTranslationWriter($this->fs, $this->lang), 'de'))->dump([
         new Translation('Schöne Grüße', 'Schöne Grüße'),
         new Translation('Open the door', 'Tür auf/zu'),
     ]);

--- a/tests/Feature/JsonEncodingTest.php
+++ b/tests/Feature/JsonEncodingTest.php
@@ -24,8 +24,8 @@ it('writes JSON translations with unescaped unicode and slashes', function () {
     $raw = $this->fs->get($this->lang.'/de.json');
 
     expect($raw)
-        ->toContain('Schöne Grüße')   // not ö / ü
-        ->toContain('Tür auf/zu')     // slash not escaped to \/
+        ->toContain('Schöne Grüße')
+        ->toContain('Tür auf/zu')
         ->not->toContain('\\u00')
         ->not->toContain('\\/');
 });

--- a/tests/Feature/JsonEncodingTest.php
+++ b/tests/Feature/JsonEncodingTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+use Bambamboole\LaravelTranslationDumper\DTO\Translation;
+use Bambamboole\LaravelTranslationDumper\TranslationDumper;
+use Illuminate\Filesystem\Filesystem;
+
+beforeEach(function () {
+    $this->fs = new Filesystem;
+    $this->lang = sys_get_temp_dir().'/ltd-json-'.uniqid('', true);
+    $this->fs->ensureDirectoryExists($this->lang);
+});
+
+afterEach(function () {
+    $this->fs->deleteDirectory($this->lang);
+});
+
+it('writes JSON translations with unescaped unicode and slashes', function () {
+    (new TranslationDumper($this->fs, $this->lang, 'de'))->dump([
+        new Translation('Schöne Grüße', 'Schöne Grüße'),
+        new Translation('Open the door', 'Tür auf/zu'),
+    ]);
+
+    $raw = $this->fs->get($this->lang.'/de.json');
+
+    expect($raw)
+        ->toContain('Schöne Grüße')   // not ö / ü
+        ->toContain('Tür auf/zu')     // slash not escaped to \/
+        ->not->toContain('\\u00')
+        ->not->toContain('\\/');
+});

--- a/tests/Feature/NestedFileDumpTest.php
+++ b/tests/Feature/NestedFileDumpTest.php
@@ -1,8 +1,14 @@
 <?php declare(strict_types=1);
 
 use Bambamboole\LaravelTranslationDumper\DTO\Translation;
+use Bambamboole\LaravelTranslationDumper\FileTranslationWriter;
 use Bambamboole\LaravelTranslationDumper\TranslationDumper;
 use Illuminate\Filesystem\Filesystem;
+
+function dumper(string $lang, string $locale = 'en'): TranslationDumper
+{
+    return new TranslationDumper(new FileTranslationWriter(new Filesystem, $lang), $locale);
+}
 
 beforeEach(function () {
     $this->fs = new Filesystem;
@@ -20,7 +26,7 @@ it('writes a dotted key into an existing nested file instead of a flat one', fun
         "<?php declare(strict_types=1);\n\nreturn ['title' => 'Sales order'];\n",
     );
 
-    (new TranslationDumper($this->fs, $this->lang, 'en'))->dump([
+    dumper($this->lang)->dump([
         new Translation('entities.salesOrder.status', 'x-entities.salesOrder.status'),
     ]);
 
@@ -34,7 +40,7 @@ it('writes a dotted key into an existing nested file instead of a flat one', fun
 });
 
 it('still writes to a flat top level file when no nested file exists', function () {
-    (new TranslationDumper($this->fs, $this->lang, 'en'))->dump([
+    dumper($this->lang)->dump([
         new Translation('foo.bar.baz', 'x-foo.bar.baz'),
     ]);
 
@@ -52,7 +58,7 @@ it('prefers the deepest existing nested file', function () {
         "<?php declare(strict_types=1);\n\nreturn ['label' => 'Lines'];\n",
     );
 
-    (new TranslationDumper($this->fs, $this->lang, 'en'))->dump([
+    dumper($this->lang)->dump([
         new Translation('entities.salesOrder.lines.total', 'x-entities.salesOrder.lines.total'),
     ]);
 
@@ -62,4 +68,19 @@ it('prefers the deepest existing nested file', function () {
     ]);
     expect($this->fs->exists($this->lang.'/en/entities.php'))->toBeFalse();
     expect($this->fs->exists($this->lang.'/en/entities/salesOrder.php'))->toBeFalse();
+});
+
+it('creates a new nested file when an explicit group is given', function () {
+    dumper($this->lang)->dump([
+        new Translation('subtitle', 'x-subtitle'),
+        new Translation('status.open', 'x-status.open'),
+    ], 'entities/salesOrder');
+
+    // The group is created from scratch with keys relative to it ...
+    expect(require $this->lang.'/en/entities/salesOrder.php')->toEqual([
+        'status' => ['open' => 'x-status.open'],
+        'subtitle' => 'x-subtitle',
+    ]);
+    // ... and nothing fell back to a flat entities.php.
+    expect($this->fs->exists($this->lang.'/en/entities.php'))->toBeFalse();
 });

--- a/tests/Feature/NestedFileDumpTest.php
+++ b/tests/Feature/NestedFileDumpTest.php
@@ -30,12 +30,10 @@ it('writes a dotted key into an existing nested file instead of a flat one', fun
         new Translation('entities.salesOrder.status', 'x-entities.salesOrder.status'),
     ]);
 
-    // It merged into the existing nested file ...
     expect(require $this->lang.'/en/entities/salesOrder.php')->toEqual([
         'status' => 'x-entities.salesOrder.status',
         'title' => 'Sales order',
     ]);
-    // ... and did not create a flat entities.php alongside it.
     expect($this->fs->exists($this->lang.'/en/entities.php'))->toBeFalse();
 });
 
@@ -47,7 +45,6 @@ it('still writes to a flat top level file when no nested file exists', function 
     expect(require $this->lang.'/en/foo.php')->toEqual([
         'bar' => ['baz' => 'x-foo.bar.baz'],
     ]);
-    // No nested foo/ directory or file was created.
     expect($this->fs->exists($this->lang.'/en/foo'))->toBeFalse();
 });
 
@@ -76,11 +73,9 @@ it('creates a new nested file when an explicit group is given', function () {
         new Translation('status.open', 'x-status.open'),
     ], 'entities/salesOrder');
 
-    // The group is created from scratch with keys relative to it ...
     expect(require $this->lang.'/en/entities/salesOrder.php')->toEqual([
         'status' => ['open' => 'x-status.open'],
         'subtitle' => 'x-subtitle',
     ]);
-    // ... and nothing fell back to a flat entities.php.
     expect($this->fs->exists($this->lang.'/en/entities.php'))->toBeFalse();
 });

--- a/tests/Feature/TranslationDumperTest.php
+++ b/tests/Feature/TranslationDumperTest.php
@@ -3,6 +3,7 @@
 namespace Bambamboole\LaravelTranslationDumper\Tests\Feature;
 
 use Bambamboole\LaravelTranslationDumper\DTO\Translation;
+use Bambamboole\LaravelTranslationDumper\FileTranslationWriter;
 use Bambamboole\LaravelTranslationDumper\TranslationDumper;
 use Illuminate\Filesystem\Filesystem;
 use PHPUnit\Framework\TestCase;
@@ -42,8 +43,7 @@ class TranslationDumperTest extends TestCase
     private function createSubject(string $folder): TranslationDumper
     {
         return new TranslationDumper(
-            new Filesystem,
-            $folder,
+            new FileTranslationWriter(new Filesystem, $folder),
             'en',
         );
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,9 +15,7 @@ abstract class TestCase extends BaseTestCase
         $this->langPath = sys_get_temp_dir().'/laravel-translation-dumper-tests/'.uniqid('lang-', true);
         (new Filesystem)->ensureDirectoryExists($this->langPath);
 
-        // The provider decides whether to decorate the translator inside register(),
-        // which runs before getEnvironmentSetUp(). The config default reads this env
-        // var, so it has to be set before the application boots.
+        // the provider reads this in register(), before getEnvironmentSetUp() runs
         putenv('DUMP_TRANSLATIONS=true');
         $_ENV['DUMP_TRANSLATIONS'] = $_SERVER['DUMP_TRANSLATIONS'] = 'true';
 

--- a/tests/Unit/TranslationDumperTest.php
+++ b/tests/Unit/TranslationDumperTest.php
@@ -40,7 +40,7 @@ class TranslationDumperTest extends TestCase
             $this->filesystem
                 ->expects($this->once())
                 ->method('put')
-                ->with($file, ArrayExporter::export($expected[$key]));
+                ->with($file, ArrayExporter::export($expected[$key]), true);
         }
 
         $this->createTranslationDumper()->dump($given);

--- a/tests/Unit/TranslationDumperTest.php
+++ b/tests/Unit/TranslationDumperTest.php
@@ -1,67 +1,53 @@
 <?php declare(strict_types=1);
 
-namespace Bambamboole\LaravelTranslationDumper\Tests\Unit;
-
-use Bambamboole\LaravelTranslationDumper\ArrayExporter;
 use Bambamboole\LaravelTranslationDumper\DTO\Translation;
 use Bambamboole\LaravelTranslationDumper\TranslationDumper;
-use Illuminate\Filesystem\Filesystem;
-use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
+use Bambamboole\LaravelTranslationDumper\TranslationWriter;
 
-class TranslationDumperTest extends TestCase
-{
-    private const TEST_LANGUAGE_FILE_PATH = '/foo/bar';
+it('routes a dotted php key into a flat top level group when no nested file exists', function () {
+    $writer = $this->createMock(TranslationWriter::class);
+    $writer->method('hasGroup')->willReturn(false);
+    $writer->expects($this->once())
+        ->method('writeGroup')
+        ->with('de', 'foo', ['bar' => ['baz' => 'x-foo.bar.baz']]);
 
-    private const TEST_LOCALE = 'de';
+    (new TranslationDumper($writer, 'de'))->dump([new Translation('foo.bar.baz', 'x-foo.bar.baz')]);
+});
 
-    private MockObject|Filesystem $filesystem;
+it('targets an existing nested group file when one matches', function () {
+    $writer = $this->createMock(TranslationWriter::class);
+    $writer->method('hasGroup')->willReturnCallback(fn ($locale, $group) => $group === 'entities/salesOrder');
+    $writer->expects($this->once())
+        ->method('writeGroup')
+        ->with('de', 'entities/salesOrder', ['title' => 'x-entities.salesOrder.title']);
 
-    protected function setUp(): void
-    {
-        $this->filesystem = $this->createMock(Filesystem::class);
-    }
+    (new TranslationDumper($writer, 'de'))->dump([
+        new Translation('entities.salesOrder.title', 'x-entities.salesOrder.title'),
+    ]);
+});
 
-    #[DataProvider('provideTestData')]
-    public function test_it_dumps_dotted_keys_as_expected(array $given, array $expected): void
-    {
-        // No translation files exist yet, so every key falls back to a flat
-        // top level file named after its first segment.
-        $this->filesystem->method('exists')->willReturn(false);
+it('writes a non dotted key to the json file', function () {
+    $writer = $this->createMock(TranslationWriter::class);
+    $writer->expects($this->never())->method('writeGroup');
+    $writer->expects($this->once())
+        ->method('writeJson')
+        ->with('de', ['Welcome back' => 'x-Welcome back']);
 
-        if (empty($expected)) {
-            $this->filesystem
-                ->expects($this->never())
-                ->method('put');
-        } else {
-            $key = array_key_first($expected);
-            $file = self::TEST_LANGUAGE_FILE_PATH.'/'.self::TEST_LOCALE.'/'.$key.'.php';
-            $this->filesystem
-                ->expects($this->once())
-                ->method('put')
-                ->with($file, ArrayExporter::export($expected[$key]), true);
-        }
+    (new TranslationDumper($writer, 'de'))->dump([new Translation('Welcome back', 'x-Welcome back')]);
+});
 
-        $this->createTranslationDumper()->dump($given);
-    }
+it('writes every key into an explicit group without probing existing files', function () {
+    $writer = $this->createMock(TranslationWriter::class);
+    $writer->expects($this->never())->method('hasGroup');
+    $writer->expects($this->once())
+        ->method('writeGroup')
+        ->with('de', 'entities/salesOrder', [
+            'subtitle' => 'x-subtitle',
+            'status' => ['open' => 'x-status.open'],
+        ]);
 
-    public static function provideTestData(): array
-    {
-        return [
-            [
-                [new Translation('foo.bar.baz', 'x-foo.bar.baz')],
-                ['foo' => ['bar' => ['baz' => 'x-foo.bar.baz']]],
-            ],
-        ];
-    }
-
-    private function createTranslationDumper(): TranslationDumper
-    {
-        return new TranslationDumper(
-            $this->filesystem,
-            self::TEST_LANGUAGE_FILE_PATH,
-            self::TEST_LOCALE,
-        );
-    }
-}
+    (new TranslationDumper($writer, 'de'))->dump([
+        new Translation('subtitle', 'x-subtitle'),
+        new Translation('status.open', 'x-status.open'),
+    ], 'entities/salesOrder');
+});


### PR DESCRIPTION
> **BREAKING CHANGE** → 3.0.0. `TranslationDumper` now takes `(TranslationWriter $writer, string $locale)` instead of `(Filesystem, languageFilePath, locale)`.

## What

- **`TranslationWriter` interface** (`hasGroup` / `writeGroup` / `writeJson`) + a shipped **`FileTranslationWriter`** that owns the filesystem, serialization (`brick/varexporter` for PHP, JSON for `.json`), merging, and persistence. Bind your own implementation to `TranslationWriter::class` to store translations elsewhere.
- **`TranslationDumper` is now pure orchestration** — classify (PHP/JSON), target the right group (probing existing nested files), build the nested arrays — and delegates writing to the writer.
- **Explicit group / nested-file creation:** `dump($translations, $group)` writes every translation into one group file, **creating it if needed**, with keys relative to the group. The group is a path under the locale dir (`entities/salesOrder` → `lang/{locale}/entities/salesOrder.php`). This resolves the ambiguity that a flat dotted key can't tell you where the file boundary is — and pairs directly with i18next namespaces, so a namespaced missing key round-trips back into the matching nested file.
- **Human-readable JSON + safe writes** (folded in): `JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES`, `LOCK_EX`, and a destructor that won't fatal on a dump failure.

## Tests

23 tests: dumper orchestration against a mocked writer (routing, existing-nested targeting, JSON, explicit group), real-FS nested/flat/deepest/create-new-group cases, UTF-8 JSON, the fixture-comparison feature test, and the provider integration test. PHPStan + Pint green.

## Note for consumers

`laravel-i18next` keeps working on the published 2.x (its constraint is `^2.0`); to adopt the new constructor + namespaced nested writes it needs a follow-up requiring `^3.0`.

